### PR TITLE
refactor button tests/setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ yarn-error.log*
 
 # other
 .eslintcache
+.idea/

--- a/src/components/Button/Button.test.js
+++ b/src/components/Button/Button.test.js
@@ -1,5 +1,5 @@
 import React, { useState } from "react"
-import { render, fireEvent, screen, getByRole, within } from "@testing-library/react"
+import { render, fireEvent, screen } from "@testing-library/react"
 import { Button } from "./Button"
 
 function ButtonWrapper() {
@@ -7,23 +7,17 @@ function ButtonWrapper() {
   return <Button name="input" text={text} onClick={() => setText("updatedText")} />
 }
 
-describe.only("<Button /> component", () => {
-  function setup() {
-    const { container } = render(<ButtonWrapper />)
-    const button = container.querySelector("button")
-    return button
-  }
+describe("<Button /> component", () => {
+  beforeEach(() => {
+    render(<ButtonWrapper />)
+  })
 
   it("should show text that is passed to it", () => {
-    const button = setup()
-    const { getByText } = within(button)
-    expect(getByText("initialText")).toBeInTheDocument()
+    expect(screen.getByText("initialText")).toBeInTheDocument()
   })
 
   it("should trigger the passed method onClick", () => {
-    const button = setup()
-    fireEvent.click(button)
-    const { getByText } = within(button)
-    expect(getByText("updatedText")).toBeInTheDocument()
+    fireEvent.click(screen.getByRole("button"))
+    expect(screen.getByText("updatedText")).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
just started off with refactoring `button.test.js` 

`screen` is built-in and has all the `getBy`, etc utils you can pull from it, so you can eliminate a bunch of code here.
any reason you created a `<ButtonWrapper>` vs importing the `<Button>`? 

glad to refactor the rest, let me know.