### PR TITLE
Change Button max width to 264px

### DIFF
--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -13,6 +13,7 @@ const StyledButton = styled.button`
   font-size: 100%;
   height: 3rem;
   min-width: 100px;
+  max-width: 264px
 `
 
 /**

--- a/src/components/InputSection/Input/Input.js
+++ b/src/components/InputSection/Input/Input.js
@@ -11,6 +11,7 @@ const StyledInput = styled.input`
   -webkit-box-shadow: none !important;
   -moz-box-shadow: none !important;
   padding: 0 0 0 1rem;
+  width: 244px;
 `
 
 /**


### PR DESCRIPTION
This PR addresses issue #19.

**Description:** Changed the max-width of button to 264px.

**Suggesting Improvements:**
The width of the Input fields of username and password does not look attractive with the width of the button.  I think the width of the input fields should be increased in an order with the width of the button.