### PR TITLE
fix for unique keys error in MobileHeader

### DIFF
--- a/src/components/Header/MobileHeader/MobileHeader.js
+++ b/src/components/Header/MobileHeader/MobileHeader.js
@@ -32,7 +32,7 @@ export const MobileHeader = function () {
 
   const menuItems = [
     ...["Profile", "Gardens"].map((option, index) => <li key={index}>{option}</li>),
-    showLogout? <li><Logout key="2" /></li> : "",
+    showLogout && <li key="logout"><Logout /></li>,
   ]
 
   const menu = <Menu>{menuItems}</Menu>


### PR DESCRIPTION
- also removed the unnecessary ternary operator

## Related to:
Resolves: #29 

## Description:
A very minor change was required to prevent a react warning from being shown in the console. I simply added a key prop to a <li> that wasn't previously there. I also removed the key prop from the <Logout /> component as it wasn't required.
I also removed the ternary operator for checking if the Logout component should render, in favour of a simple true/false check which will not return the Logout component if the showLogout variable is false.


## Tests: none 

## Checklist:
Please put an x in each box that you have completed

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [] I have commented my code in any hard-to-understand areas
- [] My changes generate no new warnings or errors
- [] I have added test instructions that prove my fix is effective or that my feature works
