### PR TITLE
Update signup mutation and login for new signup schema

### DIFF
--- a/src/components/MockComponents/MockComponent.test.js
+++ b/src/components/MockComponents/MockComponent.test.js
@@ -1,35 +1,37 @@
-import React from 'react';
-import { render, screen, waitForElementToBeRemoved } from '@testing-library/react';
-import { ApolloProvider } from '@apollo/client'
-import client from '../../ApolloClient';
-import userEvent from '@testing-library/user-event';
-import MockComponent from './mockComponent'
-import {server} from '../../mocks/server';
+import React from "react"
+import { render, screen, waitForElementToBeRemoved } from "@testing-library/react"
+import { ApolloProvider } from "@apollo/client"
+import client from "../../ApolloClient"
+import userEvent from "@testing-library/user-event"
+import MockComponent from "./MockComponent"
+import { server } from "../../mocks/server"
 
 beforeEach(() => server.listen())
-afterAll(() => server.close());
+afterAll(() => server.close())
 
-describe('<MockComponent/>', () => {
+describe("<MockComponent/>", () => {
   beforeEach(() => {
     render(
-    <ApolloProvider client={client}>
-      <MockComponent/>
-    </ApolloProvider>
+      <ApolloProvider client={client}>
+        <MockComponent />
+      </ApolloProvider>
     )
   })
-  it('renders properly', async () => {
-    expect(await screen.findByRole('button', {name: /Sup/i})).toBeInTheDocument();
-  });
-  it('renders a loader while loading', () => {
-    expect(screen.getByText(/Loading/i)).toBeInTheDocument();
+  it("renders properly", async () => {
+    expect(await screen.findByRole("button", { name: /Sup/i })).toBeInTheDocument()
   })
-  it('retrieves and renders data', async () => {
+  it("renders a loader while loading", () => {
+    expect(screen.getByText(/Loading/i)).toBeInTheDocument()
+  })
+  it("retrieves and renders data", async () => {
     waitForElementToBeRemoved(() => screen.findByText(/Loading.../i))
-    expect(await screen.findByRole('heading', {name: /abc123/i})).toBeInTheDocument();
+    expect(
+      await screen.findByRole("heading", { name: /abc123/i })
+    ).toBeInTheDocument()
   })
-  it('calls MOCK_MUTATION on button click', async () => {
-    const makeThingMock = jest.spyOn(client, 'mutate')
-    await userEvent.click(await screen.findByRole('button', {name: /Sup/i}));
-    expect(makeThingMock).toHaveBeenCalled();
+  it("calls MOCK_MUTATION on button click", async () => {
+    const makeThingMock = jest.spyOn(client, "mutate")
+    await userEvent.click(await screen.findByRole("button", { name: /Sup/i }))
+    expect(makeThingMock).toHaveBeenCalled()
   })
-});
+})

--- a/src/mutations/mutations.js
+++ b/src/mutations/mutations.js
@@ -16,6 +16,7 @@ export const SIGNUP_MUTATION = gql`
         email
         password
       }
+      token
     }
   }
 `


### PR DESCRIPTION
## Description:
On the backend, we updated the `createUser` mutation (`SIGNUP_MUTATION`) to return a JWT token with the response. The changes here alter the call to `SIGNUP_MUTATION` to request the token, and update `Login.js` to receive the token, save it as a cookie, update state, and reroute to the next component in the app flow. These changes eliminate the need to call the login/signin mutation immediately after the `SIGNUP_MUTATION` terminates, saving us a network request.

## Tests: 
I have not written any tests, am waiting on updates to `Login.test.js` from @paytonagreen 

## Checklist:
Please put an x in each box that you have completed

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in any hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [] I have added test instructions that prove my fix is effective or that my feature works
